### PR TITLE
Make l10n structure ready for translators

### DIFF
--- a/update_l10n.sh
+++ b/update_l10n.sh
@@ -11,7 +11,7 @@ CFG=babel.cfg
 L10NDIR="./translations/"
 
 # Get pybabel path in different distros
-PYBABEL_LIST="/usr/bin/pybabel2 /usr/bin/babel-python2 /usr/bin/pybabel"
+PYBABEL_LIST="/usr/bin/pybabel2 /usr/bin/babel-python2 /usr/bin/pybabel /usr/local/bin/pybabel"
 unset PYBABEL
 for BIN in $PYBABEL_LIST; do
     if [ -x $BIN ]; then

--- a/update_l10n.sh
+++ b/update_l10n.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Automatizes POT file generation and existent PO update for translation
+
+##### Script Configuration #####
+COPYRIGHT_HOLDER="Alexandre Diaz"
+MSGID_BUGS_ADDR="https://github.com/CytraL/twp/issues"
+CHARSET="UTF-8"
+
+POT=messages.pot
+CFG=babel.cfg
+L10NDIR="./translations/"
+
+# Get pybabel path in different distros
+PYBABEL_LIST="/usr/bin/pybabel2 /usr/bin/babel-python2 /usr/bin/pybabel"
+unset PYBABEL
+for BIN in $PYBABEL_LIST; do
+    if [ -x $BIN ]; then
+        PYBABEL=$BIN
+        break 2
+    fi
+done
+unset BIN; unset PYBABEL_LIST
+################################
+
+##### Initial Verification #####
+if [ ! -d $L10NDIR ]; then
+	echo "Error: $L10NDIR not found. Are you running this script from root dir?"
+	exit 1
+fi
+
+if [ ! -r $CFG ]; then
+    echo "Error: $CFG not found."
+    exit 1
+fi
+
+if [ ! -x $PYBABEL ]; then
+        echo "Error: pybabel not found. Please make sure it is installed."
+        exit 1
+fi
+#################################
+
+# TODO: Add verification for jinja installed
+# Generates POT files
+$PYBABEL extract --charset=$CHARSET --mapping=$CFG --output=$POT   \
+    --no-wrap --sort-by-file --msgid-bugs-address=$MSGID_BUGS_ADDR \
+    --copyright-holder="$COPYRIGHT_HOLDER"  "$L10NDIR"               || exit 1
+
+# Updates existent PO files
+$PYBABEL update --input-file=$POT --output-dir="$L10NDIR" --previous || exit 1
+
+# Compiles existent PO files, generating MO files
+$PYBABEL compile --directory="$L10NDIR" --statistics                 || exit 1


### PR DESCRIPTION
Currently, translator have to run "pybabel" command to make POT and the directory structure, which is nicely documented on README.md.

However, not all translators are as much tech-savy or have the environment (Linux installed, pybabel or Python libs) to do those tasks. If the l10n structure is ready for the translator to get POT and do the translation job, the scenario will be more translator-firendly, which might get even more contribution.

Here is the summary of my suggestions:
1. Have a script for POT generation and existent PO files update
2. Run this script from time to time
3. Do not lean on the translator to build directory structure

I could help with such script - just say it.

(1)
The idea of a script is to make translators life easier to get what he wants: a POT for translation

The need for running a few build and extract commands might scare some translators, even if they COULD have the scenario. Remember that not all are tech-savy or even want to spend time figuring command lines. So, a script that make it all ready (POT and PO updates) would be an invite for their contribution.

(2)
The ideia of the developer running this script from time to time is to have both POT and PO files updated whenever you want. For example, PO files would be ready (new strings, out-dated maked as "fuzzy", etc.) for a new release with a singles run of this script.

Also, having POT updated by the developer, makes a lot easier for the translator that not necessarily have run the script, therefore wouldn't need to install libraries and software that might now be used for other scenario. They would just get the POT or PO (needing attention) and would deliver the PO. Simple.

By the way, from time to time I meant like in a release or whenever the developer believes a big amount of strings changed.

(3)
The directory structure could also be created with a script (maybe another one), not needing the translator run pybabel manually. This also a suggestion to make it easier for the translator.

The translator provides the PO, which would be stored in a folder (lets say: <root>/locale/po/) named only with the language code in the name (<lang>.po, e.g. pt_BR.po) and a script would be run through this directory to build the translation structure (lets say: <root>/locale/translations/<lang>/LC_MESSAGES/)
